### PR TITLE
[DOC] Add CLI page and use BibTeX for references

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,24 +7,85 @@ API
 ###
 
 
-.. _api_module_ref:
+.. _api_pySPFM_ref:
 
 **************************************************
-:mod:`pySPFM.module`: Module description
+:mod:`pySPFM.pySPFM`: The pySPFM workflow
 **************************************************
 
-.. automodule:: pySPFM.module
+.. automodule:: pySPFM.pySPFM
    :no-members:
    :no-inherited-members:
 
-.. currentmodule:: pySPFM.module
+.. currentmodule:: pySPFM.pySPFM
 
 .. autosummary::
    :toctree: generated/
-   :template: class.rst
-
-   pySPFM.module.Class
-
    :template: function.rst
 
-   pySPFM.module.function
+   pySPFM.pySPFM.pySPFM
+
+.. _api_deconvolution_ref:
+
+**************************************************
+:mod:`pySPFM.deconvolution`: Deconvolution methods
+**************************************************
+
+.. automodule:: pySPFM.deconvolution
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: pySPFM.deconvolution
+
+.. autosummary::
+   :toctree: generated/
+   :template: module.rst
+
+   pySPFM.deconvolution.debiasing
+   pySPFM.deconvolution.fista
+   pySPFM.deconvolution.hrf_matrix
+   pySPFM.deconvolution.lars
+   pySPFM.deconvolution.select_lambda
+   pySPFM.deconvolution.spatial_regularization
+
+
+.. _api_io_ref:
+
+**************************************************
+:mod:`pySPFM.io`: Input/Output methods
+**************************************************
+
+.. automodule:: pySPFM.io
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: pySPFM.io
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   pySPFM.io.read_data
+   pySPFM.io.reshape_data
+   pySPFM.io.update_header
+   pySPFM.io.write_data
+
+
+.. _api_utils_ref:
+
+**************************************************
+:mod:`pySPFM.utils`: Miscellaneous utility methods
+**************************************************
+
+.. automodule:: pySPFM.utils
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: pySPFM.utils
+
+.. autosummary::
+   :toctree: generated/
+   :template: module.rst
+
+   pySPFM.utils.setup_loggers
+   pySPFM.utils.teardown_loggers

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,16 @@
+Command Line Interface
+========================
+
+To use pySPFM from the command line, open a terminal window and type:
+
+.. code-block:: bash
+
+	pySPFM --help
+
+This will print the instructions for using the command line interface in your
+command line.
+
+.. argparse::
+   :ref: pySPFM.cli.run._get_parser
+   :prog: pySPFM
+   :func: _get_parser

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,8 @@ extensions = [
     "sphinx.ext.linkcode",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
+    "sphinxarg.ext",  # argparse
+    "sphinxcontrib.bibtex",  # for foot-citations
 ]
 
 if LooseVersion(sphinx.__version__) < LooseVersion("1.4"):
@@ -143,6 +145,14 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# -----------------------------------------------------------------------------
+# sphinxcontrib-bibtex
+# -----------------------------------------------------------------------------
+bibtex_bibfiles = ["./references.bib"]
+bibtex_style = "unsrt"
+bibtex_reference_style = "author_year"
+bibtex_footbibliography_header = ""
 
 
 def setup(app):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ pySPFM is licensed under GNU Lesser General Public License version 2.1.
    :caption: Contents:
 
    api
-   example_analysis.ipynb
+   cli
 
 
 ******************

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,0 +1,57 @@
+@article{caballero2019deconvolution,
+    title={A deconvolution algorithm for multi-echo functional MRI: Multi-echo Sparse Paradigm Free Mapping},
+    author={Caballero-Gaudes, C{\'e}sar and Moia, Stefano and Panwar, Puja and Bandettini, Peter A and Gonzalez-Castillo, Javier},
+    journal={Neuroimage},
+    volume={202},
+    pages={116081},
+    year={2019},
+    publisher={Elsevier},
+    url={https://doi.org/10.1016/j.neuroimage.2019.116081},
+    doi={10.1016/j.neuroimage.2019.116081}
+}
+
+@inproceedings{gaudes2011paradigm,
+    title={Paradigm-free mapping with morphological component analysis: Getting most out of fMRI data},
+    author={Gaudes, C{\'e}sar Caballero and Van De Ville, Dimitri and Petridou, Natalia and Lazeyras, Fran{\c{c}}ois and Gowland, Penny},
+    booktitle={Wavelets and Sparsity XIV},
+    volume={8138},
+    pages={384--394},
+    year={2011},
+    organization={SPIE},
+    url={https://doi.org/10.1117/12.893920},
+    doi={10.1117/12.893920}
+}
+
+@article{gaudes2013paradigm,
+    title={Paradigm free mapping with sparse regression automatically detects single-trial functional magnetic resonance imaging blood oxygenation level dependent responses},
+    author={Gaudes, Cesar Caballero and Petridou, Natalia and Francis, Susan T and Dryden, Ian L and Gowland, Penny A},
+    journal={Human brain mapping},
+    volume={34},
+    number={3},
+    pages={501},
+    year={2013},
+    publisher={Wiley-Blackwell},
+    url={https://doi.org/10.1002/hbm.21452},
+    doi={10.1002/hbm.21452}
+}
+
+@article{karahanouglu2013total,
+    title={Total activation: fMRI deconvolution through spatio-temporal regularization},
+    author={Karahano{\u{g}}lu, Fikret I{\c{s}}{\i}k and Caballero-Gaudes, C{\'e}sar and Lazeyras, Fran{\c{c}}ois and Van De Ville, Dimitri},
+    journal={Neuroimage},
+    volume={73},
+    pages={121--134},
+    year={2013},
+    publisher={Elsevier},
+    url={https://doi.org/10.1016/j.neuroimage.2013.01.067},
+    doi={10.1016/j.neuroimage.2013.01.067}
+}
+
+@article{urunuela2021hemodynamic,
+    title={Hemodynamic Deconvolution Demystified: Sparsity-Driven Regularization at Work},
+    author={Uru{\~n}uela, Eneko and Bolton, Thomas AW and Van De Ville, Dimitri and Caballero-Gaudes, C{\'e}sar},
+    journal={arXiv preprint arXiv:2107.12026},
+    year={2021},
+    url={http://arxiv.org/abs/2107.12026},
+    doi={2107.12026}
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,10 @@ include_package_data = False
 [options.extras_require]
 doc =
     sphinx>=1.5.3
+    sphinx-argparse
+    sphinx-copybutton
     sphinx_rtd_theme
+    sphinxcontrib-bibtex
 tests =
     codecov
     coverage<5.0


### PR DESCRIPTION
Closes None, but it should get the RTD site successfully building again.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add the BibTeX Sphinx extension to the docs requirements.
- Add references from the README to a new `docs/references.bib` file. These can be referenced in docstrings and in the documentation.
- Add a `docs/cli.rst` file that documents the command-line interface.
- Fill in `docs/api.rst` with the current modules and functions.
