### PR TITLE
Add option to treat the mask as an atlas

### DIFF
--- a/pySPFM/cli/run.py
+++ b/pySPFM/cli/run.py
@@ -227,6 +227,14 @@ def _get_parser():
         default=1e-6,
     )
     optional.add_argument(
+        "-atlas",
+        "--atlas",
+        dest="is_atlas",
+        action="store_true",
+        help="Use provided mask as an atlas (default = False).",
+        default=False,
+    )
+    optional.add_argument(
         "-debug",
         "--debug",
         dest="debug",

--- a/pySPFM/deconvolution/fista.py
+++ b/pySPFM/deconvolution/fista.py
@@ -165,7 +165,7 @@ def fista(
                 S = proximal_operator_lasso(z_ista_S, c_ist * lambda_)
 
             t_fista_old = t_fista
-            t_fista = 0.5 * (1 + np.sqrt(1 + 4 * (t_fista_old ** 2)))
+            t_fista = 0.5 * (1 + np.sqrt(1 + 4 * (t_fista_old**2)))
 
             y_fista_S = S + (S - S_old) * (t_fista_old - 1) / t_fista
 

--- a/pySPFM/pySPFM.py
+++ b/pySPFM/pySPFM.py
@@ -47,6 +47,7 @@ def pySPFM(
     spatial_dim=3,
     mu=0.01,
     tolerance=1e-6,
+    is_atlas=False,
     debug=False,
     quiet=False,
 ):
@@ -92,7 +93,7 @@ def pySPFM(
 
     LGR.info("Reading data...")
     if n_te == 1:
-        data_masked, data_header, mask_img = read_data(data_fn[0], mask_fn)
+        data_masked, data_header, mask = read_data(data_fn[0], mask_fn, is_atlas=is_atlas)
         nscans = data_masked.shape[0]
         nvoxels = data_masked.shape[1]
     elif n_te > 1:
@@ -102,7 +103,7 @@ def pySPFM(
             data_fn = data_fn[0].split(" ")
 
         for te_idx in range(n_te):
-            data_temp, data_header, mask_img = read_data(data_fn[te_idx], mask_fn)
+            data_temp, data_header, mask = read_data(data_fn[te_idx], mask_fn, is_atlas=is_atlas)
             if te_idx == 0:
                 data_masked = data_temp
                 nscans = data_temp.shape[0]
@@ -203,7 +204,7 @@ def pySPFM(
             estimates_tikhonov = spatial_tikhonov(
                 final_estimates,
                 final_estimates - estimates_spatial + data_masked,
-                mask_img,
+                mask,
                 max_iter_spatial,
                 spatial_dim,
                 spatial_lambda,
@@ -241,7 +242,12 @@ def pySPFM(
         estimates_block = final_estimates
         output_name = f"{output_filename}_innovation.nii.gz"
         write_data(
-            estimates_block, os.path.join(out_dir, output_name), mask_img, data_header, command_str
+            estimates_block,
+            os.path.join(out_dir, output_name),
+            mask,
+            data_header,
+            command_str,
+            is_atlas=is_atlas,
         )
 
         if not debias:
@@ -256,7 +262,12 @@ def pySPFM(
     elif n_te > 1:
         output_name = f"{output_filename}_DR2.nii.gz"
     write_data(
-        estimates_spike, os.path.join(out_dir, output_name), mask_img, data_header, command_str
+        estimates_spike,
+        os.path.join(out_dir, output_name),
+        mask,
+        data_header,
+        command_str,
+        is_atlas=is_atlas,
     )
 
     # Save fitts
@@ -265,9 +276,10 @@ def pySPFM(
         write_data(
             fitts,
             os.path.join(out_dir, output_name),
-            mask_img,
+            mask,
             data_header,
             command_str,
+            is_atlas=is_atlas,
         )
     elif n_te > 1:
         for te_idx in range(n_te):
@@ -276,9 +288,10 @@ def pySPFM(
             write_data(
                 te_data,
                 os.path.join(out_dir, output_name),
-                mask_img,
+                mask,
                 data_header,
                 command_str,
+                is_atlas=is_atlas,
             )
 
     # Save noise estimate
@@ -292,9 +305,10 @@ def pySPFM(
         write_data(
             np.expand_dims(noise_estimate, axis=0),
             os.path.join(out_dir, output_name),
-            mask_img,
+            mask,
             data_header,
             command_str,
+            is_atlas=is_atlas,
         )
 
     # Save lambda
@@ -302,9 +316,10 @@ def pySPFM(
     write_data(
         np.expand_dims(lambda_map, axis=0),
         os.path.join(out_dir, output_name),
-        mask_img,
+        mask,
         data_header,
         command_str,
+        is_atlas=is_atlas,
     )
 
     LGR.info("Results saved.")


### PR DESCRIPTION
<!---
This is a suggested pull request template for pySPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #12.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Adds a new CLI argument to flag that the mask is an atlas.
- The mask is read with `NiftiLabelsMasker` when `is_atlas` is `True`.
- The data in the regions are averaged when masking the data.
