### PR TITLE
Remove unused n_jobs argument from stability selection call

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The Python version of AFNI's [3dPFM]() and [3dMEPFM]() with some extra features 
 [![CircleCI](https://circleci.com/gh/eurunuela/pySPFM/tree/main.svg?style=shield)](https://circleci.com/gh/eurunuela/pySPFM/tree/main)
 [![Documentation Status](https://readthedocs.org/projects/pyspfm/badge/?version=latest)](http://pyspfm.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/eurunuela/pySPFM/branch/main/graph/badge.svg)](https://codecov.io/gh/eurunuela/pySPFM)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 ## References
 

--- a/pySPFM/deconvolution/stability_selection.py
+++ b/pySPFM/deconvolution/stability_selection.py
@@ -66,13 +66,10 @@ def calculate_auc(coefs, lambdas):
     return auc
 
 
-def stability_selection(hrf_norm, data, n_lambdas, n_surrogates, n_jobs):
+def stability_selection(hrf_norm, data, n_lambdas, n_surrogates):
     # Get n_scans, n_echos, n_voxels
     n_scans = hrf_norm.shape[1]
     n_echos = int(np.ceil(hrf_norm.shape[0] / n_scans))
-
-    # Initialize the scheduler
-    # _, cluster = dask_scheduler(n_jobs)
 
     # Initialize variables to store the results
     estimates = np.zeros((n_scans, n_lambdas, n_surrogates))

--- a/pySPFM/workflows/pySPFM.py
+++ b/pySPFM/workflows/pySPFM.py
@@ -546,7 +546,6 @@ def pySPFM(
                     data_temp_reg[:, vox_idx],
                     n_lambdas,
                     n_surrogates,
-                    n_jobs,
                 )
                 futures.append(fut)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for pySPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes none.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Removes unused `n_jobs` arguments from `stability_selection` function.
